### PR TITLE
Add env_file for postgres container

### DIFF
--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -16,6 +16,7 @@ services:
   postgres:
     container_name: postgres
     image: postgres
+    env_file: '.env'
     restart: always
     ports:
       - "5432:5432"


### PR DESCRIPTION
When you run `docker-compose up` it gives the error:
```
postgres    | Error: Database is uninitialized and superuser password is not specified.
postgres    |        You must specify POSTGRES_PASSWORD to a non-empty value for the
postgres    |        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
postgres    |
postgres    |        You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
postgres    |        connections without a password. This is *not* recommended.
postgres    |
postgres    |        See PostgreSQL documentation about "trust":
postgres    |        https://www.postgresql.org/docs/current/auth-trust.html
postgres    | Error: Database is uninitialized and superuser password is not specified.
postgres    |        You must specify POSTGRES_PASSWORD to a non-empty value for the
postgres    |        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
postgres    |
postgres    |        You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
postgres    |        connections without a password. This is *not* recommended.
postgres    |
postgres    |        See PostgreSQL documentation about "trust":
postgres    |        https://www.postgresql.org/docs/current/auth-trust.html
postgres exited with code 1
```

I see the POSTGRES_PASSWORD var already exists in `.env` so I've added `env_file` to the postgres config so it can see these variables, the same as was done for mysql.